### PR TITLE
fix: 프론트엔드 네트워크 인식 오류

### DIFF
--- a/docker-compose-app.yml
+++ b/docker-compose-app.yml
@@ -52,3 +52,7 @@ services:
       - "8082:8080"
     networks:
       - cream-network
+
+networks:
+  cream-network:
+    driver: bridge


### PR DESCRIPTION
# 🚀 Pull Request Title

## 🔗 1. 관련 이슈 (Related Issue(s))

Related to #12

## ✨ 2. 작업 내역 / 주요 변경 사항 요약 (Summary of Work)

- Spring 서버 간 네트워크 명시 부재로 인해 프론트엔드 CD 과정이 실패하는 현상 有
- docker-compose-app.yml에 네트워크 설정 명시를 통해 해결 시도

## ✅ 3. PR 제출 전 확인사항 (Checklist)

- [x] 코딩 컨벤션을 준수했습니다.
- [x] 모든 로컬 테스트를 통과했습니다.
- [x] 브랜치 충돌이 없습니다. (develop 브랜치에 merge 가능 상태)

## 🖼️ 4. 첨부 이미지 (선택)


## 🧑‍💻 5. 리뷰 요구사항 (Reviewer Guidance / Request) (선택)

-
